### PR TITLE
Fix up/down being flipped in connection graph generation

### DIFF
--- a/chunk.js
+++ b/chunk.js
@@ -45,12 +45,12 @@ function Chunk(grid) {
 			this.touchedByFlood[1] = true;
 			return;
 		}
-		else if(y < 0){
+		else if(y > 15){
 			++this.touchedByFloodCount;
 			this.touchedByFlood[2] = true;
 			return;
 		}
-		else if(y > 15){
+		else if(y < 0){
 			++this.touchedByFloodCount;
 			this.touchedByFlood[3] = true;
 			return;


### PR DESCRIPTION
Up and down are flipped in the connection graph. See here:
![image](https://github.com/Tomcc/tomcc.github.io/assets/1145038/60d03fa4-697f-42c5-80ff-3d376e0668f9)

After the fix it looks correct:
![image](https://github.com/Tomcc/tomcc.github.io/assets/1145038/2271e0ac-c8b9-4da3-a211-9e23a05d51a3)
